### PR TITLE
[FIX] Slurm tmp.db random generation

### DIFF
--- a/evcouplings/utils/batch.py
+++ b/evcouplings/utils/batch.py
@@ -606,6 +606,14 @@ class SlurmSubmitter(AClusterSubmitter):
 
         self.__db = PersistentDict(self.__db_path)
 
+    def __del__(self):
+        try:
+            self.__db.close()
+            if self.__is_temp_db:
+                os.remove(self.__db_path)
+        except AttributeError:
+            pass
+          
     @property
     def isBlocking(self):
         return self.__blocking


### PR DESCRIPTION
[FIX] Slurm does not generate tmp.db files during registering anymore.