### PR TITLE
Closes #52

### DIFF
--- a/evcouplings/utils/app.py
+++ b/evcouplings/utils/app.py
@@ -58,7 +58,7 @@ def substitute_config(**kwargs):
         "id": ("align", "seqid_filter"),
         "seqcov": ("align", "minimum_sequence_coverage"),
         "colcov": ("align", "minimum_column_coverage"),
-        "theta": ("couplings", "theta"),
+        "theta": ("global", "theta"),
         "plmiter": ("couplings", "iterations"),
         "queue": ("environment", "queue"),
         "time": ("environment", "time"),


### PR DESCRIPTION
theta was moved to global section in config file, but command line still set theta for couplings section only (i.e. overridden by global)