### PR TITLE
[Bugfix] Minor bugfixes to complexes code

### DIFF
--- a/evcouplings/complex/similarity.py
+++ b/evcouplings/complex/similarity.py
@@ -45,7 +45,7 @@ def read_species_annotation_table(annotation_file):
     # and "Tax" is for Uniref
     for column in SPECIES_ANNOTATION_COLUMNS:
         # if this column contains non-null values
-        if data[column].isnull().any():
+        if data[column].notnull().any():
             # use that column to extract data
             annotation_column = column
             break

--- a/evcouplings/visualize/pairs.py
+++ b/evcouplings/visualize/pairs.py
@@ -393,7 +393,7 @@ def complex_contact_map(intra1_ecs, intra2_ecs, inter_ecs,
 
     # Don't compute inter boundaries unless we have inter 
     # ecs or distances
-    if inter_ecs is not None or d_inter is not None:
+    if (inter_ecs is not None and not inter_ecs.empty) or d_inter is not None:
         inter_boundaries = list(
             find_boundaries(
                 boundaries, ecs=inter_ecs, monomer=d_inter,


### PR DESCRIPTION
1. best hit concatenation was failing on uniref alignments due to not properly finding the annotation column. This does not affect uniprot alignments. 

2. Not properly testing for absence of inter ECs before calling complex contact map visualization.