### PR TITLE
Minor fixes to complexes pipeline

### DIFF
--- a/evcouplings/compare/protocol.py
+++ b/evcouplings/compare/protocol.py
@@ -665,7 +665,7 @@ def complex(**kwargs):
         # initialize output EC files
         "ec_compared_all_file": prefix + "_CouplingScoresCompared_all.csv",
         "ec_compared_longrange_file": prefix + "_CouplingScoresCompared_longrange.csv",
-        "ec_compared_inter_file": prefix + "_CouplingsScoresCompared_inter.csv",
+        "ec_compared_inter_file": prefix + "_CouplingScoresCompared_inter.csv",
 
         # initialize output inter distancemap files
         "distmap_inter": prefix + "_distmap_inter",

--- a/evcouplings/complex/alignment.py
+++ b/evcouplings/complex/alignment.py
@@ -119,17 +119,17 @@ def write_concatenated_alignment(id_pairing, alignment_1, alignment_2,
         )
 
     # concatenate strings
-    sequences_full = OrderedDict({
-        header: np.concatenate([seq1, seq2]) for header, seq1, seq2 in sequences_to_write
-    })
+    sequences_full = OrderedDict([
+        (header, np.concatenate([seq1, seq2])) for header, seq1, seq2 in sequences_to_write
+    ])
 
-    sequences_monomer_1 = OrderedDict({
-        header: seq1 for header, seq1, seq2 in sequences_to_write
-    })
+    sequences_monomer_1 = OrderedDict([
+        (header, seq1) for header, seq1, seq2 in sequences_to_write
+    ])
 
-    sequences_monomer_2 = OrderedDict({
-        header: seq2 for header, seq1, seq2 in sequences_to_write
-    })
+    sequences_monomer_2 = OrderedDict([
+        (header, seq2) for header, seq1, seq2 in sequences_to_write
+    ])
 
     full_ali = Alignment.from_dict(sequences_full)
     monomer_ali_1 = Alignment.from_dict(sequences_monomer_1)

--- a/evcouplings/complex/similarity.py
+++ b/evcouplings/complex/similarity.py
@@ -114,7 +114,7 @@ def find_paralogs(target_id, annotation_data, identity_threshold):
     """
 
     # output of parse_header is (ID, region_start, region_end)
-    base_query_id,_,_ = parse_header(target_id)
+    base_query_id, _, _ = parse_header(target_id)
 
     # get all the rows that have an id that contains the
     # query id. This includes the focus sequence and its hit to

--- a/evcouplings/complex/similarity.py
+++ b/evcouplings/complex/similarity.py
@@ -113,13 +113,14 @@ def find_paralogs(target_id, annotation_data, identity_threshold):
         Entries are paralogs found in the same genome as the query id
     """
 
-    base_query = parse_header(target_id)
+    # output of parse_header is (ID, region_start, region_end)
+    base_query_id,_,_ = parse_header(target_id)
 
     # get all the rows that have an id that contains the
     # query id. This includes the focus sequence and its hit to
     # itself in the database.
 
-    contains_annotation = [ True if base_query in x else False for x in annotation_data.id.str ]
+    contains_annotation = [ True if base_query_id in x else False for x in annotation_data.id]
     query_hits = annotation_data.loc[contains_annotation , :]
     # get the species annotation for the query sequence
     query_species = list(query_hits.species.dropna())

--- a/evcouplings/complex/similarity.py
+++ b/evcouplings/complex/similarity.py
@@ -120,7 +120,7 @@ def find_paralogs(target_id, annotation_data, identity_threshold):
     # query id. This includes the focus sequence and its hit to
     # itself in the database.
 
-    contains_annotation = [ True if base_query_id in x else False for x in annotation_data.id]
+    contains_annotation = [base_query_id in x for x in annotation_data.id]
     query_hits = annotation_data.loc[contains_annotation , :]
     # get the species annotation for the query sequence
     query_species = list(query_hits.species.dropna())

--- a/evcouplings/couplings/protocol.py
+++ b/evcouplings/couplings/protocol.py
@@ -482,6 +482,11 @@ def complex(**kwargs):
         )
         ecs_longrange.to_csv(outcfg["ec_longrange_file"], index=False)
 
+    # save just the inter protein ECs
+    outcfg["ec_inter_file"] = prefix + "_CouplingScores_inter.csv"
+    inter_ecs = ecs.query("segment_i != segment_j")
+    inter_ecs.to_csv(outcfg["inter_ec_file"], index=False)
+
     # also create line-drawing script (for multiple chains)
     outcfg["ec_lines_pml_file"] = prefix + "_draw_ec_lines.pml"
     L = outcfg["num_sites"]

--- a/evcouplings/couplings/protocol.py
+++ b/evcouplings/couplings/protocol.py
@@ -452,7 +452,7 @@ def complex(**kwargs):
     ## TODO: eventually have this accomplished by _postprocess_inference
     ## right now avoiding a second call with a different ec_filter
     ecs = pd.read_csv(outcfg["ec_file"])
-    outcfg["inter_ec_file"] = prefix + "_CouplingScoresInter.csv"
+    outcfg["inter_ec_file"] = prefix + "_CouplingScores_inter.csv"
     inter_ecs = ecs.query("segment_i != segment_j")
     inter_ecs.to_csv(outcfg["inter_ec_file"], index=False)
 


### PR DESCRIPTION
See commits. The following major changes were made:

1. correctly identifying paralogs for best reciprocal hit pairing. This was broken due to incorrect handling of outputs of parse_header.

2. couplings stage now outputs a CouplingScores_inter.csv file. 