### PR TITLE
Precomputed databases for EVcomplex added and documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ Please see
 
 for how to download the respective databases. Note that this may take a while, especially the generation of post-processed SIFTS mapping files. 
 
+#### Sequence databases for EVcomplex
+Running the complexes pipeline within EVcouplings (aka EVcomplex) requires two special pre-computed databases. You can download these databases here:
+
+ena_genome_location_table: https://marks.hms.harvard.edu/evcomplex_databases/cds_pro_2017_02.txt
+uniprot_to_embl_table: https://marks.hms.harvard.edu/evcomplex_databases/idmapping_uniprot_embl_2017_02.txt
+
+These databases should be saved in your local environment. Paths to local copies of these databases need to be added to the complexes configuration file. 
+
+In future releases these databases will be generated automatically. 
+
 #### Other sequence databases
 
 You can however use any sequence database of your choice in FASTA format if you prefer to. The database for any particular job needs to be defined in the job configuration file ("databases" section) and set as the input database in the "alignment" section.

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ Please see
 for how to download the respective databases. Note that this may take a while, especially the generation of post-processed SIFTS mapping files. 
 
 #### Sequence databases for EVcomplex
-Running the complexes pipeline within EVcouplings (aka EVcomplex) requires two special pre-computed databases. You can download these databases here:
+Running the EVcouplings pipeline for protein complexes (aka EVcomplex) requires two pre-computed databases. You can download these databases here:
 
 ena_genome_location_table: https://marks.hms.harvard.edu/evcomplex_databases/cds_pro_2017_02.txt
 uniprot_to_embl_table: https://marks.hms.harvard.edu/evcomplex_databases/idmapping_uniprot_embl_2017_02.txt
 
-These databases should be saved in your local environment. Paths to local copies of these databases need to be added to the complexes configuration file. 
+Save these databases in your local environment, and then add the paths to the local copies of these databases to your config file for the complex pipeline. 
 
 In future releases these databases will be generated automatically. 
 

--- a/config/sample_config_complex.txt
+++ b/config/sample_config_complex.txt
@@ -482,5 +482,11 @@ tools:
     psipred: /groups/marks/software/runpsipred
     cns: /groups/marks/pipelines/evcouplings/software/cns_solve_1.21/intel-x86_64bit-linux/bin/cns
     maxcluster: /groups/marks/pipelines/evcouplings/software/maxcluster64bit
+    
+    # the following two databases are exclusive to EVcomplex and need to be manually downloaded and saved locally
+    # then add the paths to your local copies of the database
+    # Download urls: 
+    # ena_genome_location_table: https://marks.hms.harvard.edu/evcomplex_databases/cds_pro_2017_02.txt
+    # uniprot_to_embl_table: https://marks.hms.harvard.edu/evcomplex_databases/idmapping_uniprot_embl_2017_02.txt 
     uniprot_to_embl_table: /groups/marks/databases/complexes/idmapping/idmapping_uniprot_embl_2017_02.txt
     ena_genome_location_table: /groups/marks/databases/complexes/ena/2017_02/cds_pro.txt


### PR DESCRIPTION
The uniprot to EMBL mapping table and the genome location table are now both downloadable and documented in the README and config files. 