### PR TITLE
Change db model to reflect webserver

### DIFF
--- a/evcouplings/utils/database.py
+++ b/evcouplings/utils/database.py
@@ -50,10 +50,10 @@ class ComputeJob(Base):
     # be used to point to cloud locations, etc.
     location = Column(String(1024))
 
-    # job group this job is associated with
+    # the job_hash this job is associated with
     # (foreign key in group key if this table
     # is present, e.g. in webserver).
-    group_id = Column(Integer)
+    group_id = Column(String(32))
 
     # job status ("pending", "running", "finished",
     # "failed", "terminated")


### PR DESCRIPTION
Change model for ComputeJob using correct type for foreign key constraint.

Currently, jobs in the web server are[ identified from MD5 hashes](https://github.com/debbiemarkslab/EVcouplings-server-backend/blob/runJob/evcouplings_server/database/models/JobGroup.py#L9) of their _prune-polluted configs_ (a.k.a.: configs containing only non-null, **job** relevant parameters (couplings, align,..) [pruned], and polluted with an additional key `seq` containing the region on which the job is calculated [polluted]).

I suppose this change won't affect anything else, right @thomashopf ?