### PR TITLE
[DOC]: updated complex config file for o2

### DIFF
--- a/config/sample_config_complex.txt
+++ b/config/sample_config_complex.txt
@@ -440,8 +440,8 @@ management:
 
 # Computational environment for batch jobs (using evcouplings command line application)
 environment:
-    # current options for engine: lsf, local (for local, only set cores and leave all other fields blank)
-    # If your batch engine of choice (SGE, Slurm, Torque) is not available yet, please consider contributing by
+    # current options for engine: lsf, slurm, local (for local, only set cores and leave all other fields blank)
+    # If your batch engine of choice (e.g. SGE, Torque) is not available yet, please consider contributing by
     # implementing it and submitting a pull request!
     # Note that "cores" will override the "cpu" parameter for "global"
     engine: slurm

--- a/config/sample_config_complex.txt
+++ b/config/sample_config_complex.txt
@@ -254,10 +254,10 @@ concatenate:
     # already present in the alignment). If blank, no filtering. If filtering, HHfilter must be installed.
     seqid_filter:
     
-    # Only include alignment columns with at least x% residues (rather than gaps) during model inference
+    # Only keep sequences that align to at least x% of the target sequence (i.e. remove fragments)
     minimum_sequence_coverage: 50
     
-    # Only keep sequences that align to at least x% of the target sequence (i.e. remove fragments)
+    # Only include alignment columns with at least x% residues (rather than gaps) during model inference
     minimum_column_coverage: 50
 
     # compute the redundancy-reduced number of effective sequences (M_eff) already in the alignment stage.
@@ -444,15 +444,15 @@ environment:
     # If your batch engine of choice (SGE, Slurm, Torque) is not available yet, please consider contributing by
     # implementing it and submitting a pull request!
     # Note that "cores" will override the "cpu" parameter for "global"
-    engine: lsf
-    queue: mcore
+    engine: slurm
+    queue: medium
     cores: 2
-    memory: 20000
-    time: 48:0
+    memory: 15000
+    time: 2-0:0:0
 
     # command that will be executed before running actual computation (can be used to set up environment)
     configuration:
-        - source activate evcouplings_env
+        - source activate evcouplings_stable
 
 # Paths to databases used by evcouplings.
 databases:
@@ -477,6 +477,8 @@ databases:
 # Paths to external tools used by evcouplings. Please refer to README.md for installation instructions and which tools are required.
 tools:
     jackhmmer: /groups/marks/pipelines/evcouplings/software/hmmer-3.1b2-linux-intel-x86_64/binaries/jackhmmer
+    hmmbuild: /groups/marks/pipelines/evcouplings/software/hmmer-3.1b2-linux-intel-x86_64/binaries/hmmbuild
+    hmmsearch: /groups/marks/pipelines/evcouplings/software/hmmer-3.1b2-linux-intel-x86_64/binaries/hmmsearch
     plmc: /groups/marks/pipelines/evcouplings/software/plmc/bin/plmc
     hhfilter: /groups/marks/pipelines/evcouplings/software/hh-suite/bin/hhfilter
     psipred: /groups/marks/software/runpsipred

--- a/config/sample_config_monomer.txt
+++ b/config/sample_config_monomer.txt
@@ -345,8 +345,8 @@ management:
 
 # Computational environment for batch jobs (using evcouplings command line application)
 environment:
-    # current options for engine: lsf, local (for local, only set cores and leave all other fields blank)
-    # If your batch engine of choice (SGE, Slurm, Torque) is not available yet, please consider contributing by
+    # current options for engine: lsf, local, slurm (for local, only set cores and leave all other fields blank)
+    # If your batch engine of choice (e.g. SGE, Torque) is not available yet, please consider contributing by
     # implementing it and submitting a pull request!
     # Note that "cores" will override the "cpu" parameter for "global"
     engine: lsf

--- a/config/sample_config_monomer_o2.txt
+++ b/config/sample_config_monomer_o2.txt
@@ -357,7 +357,7 @@ environment:
 
     # command that will be executed before running actual computation (can be used to set up environment)
     configuration:
-        - source activate evcouplings_o2
+        - source activate evcouplings_stable
 
 # Paths to databases used by evcouplings.
 databases:

--- a/config/sample_config_monomer_o2.txt
+++ b/config/sample_config_monomer_o2.txt
@@ -345,8 +345,8 @@ management:
 
 # Computational environment for batch jobs (using evcouplings command line application)
 environment:
-    # current options for engine: lsf, local (for local, only set cores and leave all other fields blank)
-    # If your batch engine of choice (SGE, Slurm, Torque) is not available yet, please consider contributing by
+    # current options for engine: lsf, local, slurm (for local, only set cores and leave all other fields blank)
+    # If your batch engine of choice (e.g. SGE, Torque) is not available yet, please consider contributing by
     # implementing it and submitting a pull request!
     # Note that "cores" will override the "cpu" parameter for "global"
     engine: slurm


### PR DESCRIPTION
- converted complex config to o2 syntax
- updated o2 syntax with new environment name in complex and monomer file
- fixed incorrect documentation of minimum_column_coverage and minimum_sequence_coverage files in complex config