### PR TITLE
Feature/enrichment update

### DIFF
--- a/evcouplings/visualize/pairs.py
+++ b/evcouplings/visualize/pairs.py
@@ -1204,6 +1204,10 @@ def enrichment_pymol_script(enrichment_table, output_file,
 
         # medium
         t.loc[t.iloc[boundary1:boundary2].index, "color"] = "orange"
+
+       # set the boundary for number of residues to be rendered as spheres
+        sphere_boundary = boundary1
+
         
     else:
         t = deepcopy(enrichment_table)
@@ -1248,8 +1252,11 @@ def enrichment_pymol_script(enrichment_table, output_file,
             t.loc[t.iloc[prior_boundary:boundary].index, "color"] = 'color{}'.format(idx)
             prior_boundary = boundary
 
+        # set the boundary for number of residues to be rendered as spheres
+        sphere_boundary = boundary_list[1]
+
     if sphere_view:
-        t.loc[t.iloc[0:boundary].index, "show"] = "spheres"
+        t.loc[t.iloc[0:sphere_boundary].index, "show"] = "spheres"
 
     if chain is not None:
         chain_sel = ", chain '{}'".format(chain)

--- a/evcouplings/visualize/pairs.py
+++ b/evcouplings/visualize/pairs.py
@@ -1206,7 +1206,7 @@ def enrichment_pymol_script(enrichment_table, output_file,
         t.loc[t.iloc[boundary1:boundary2].index, "color"] = "orange"
 
        # set the boundary for number of residues to be rendered as spheres
-        sphere_boundary = boundary1
+        sphere_boundary = boundary2
 
         
     else:


### PR DESCRIPTION
Renders top 22% of residues as spheres for the new enrichment color scheme (each color bin is 11% of total). Renders the top 15% of residues as spheres for the legacy color scheme. This was requested as a hotfix yesterday. 