### PR TITLE
Rename num_sequences to num_valid_sequences

### DIFF
--- a/evcouplings/couplings/protocol.py
+++ b/evcouplings/couplings/protocol.py
@@ -234,7 +234,7 @@ def infer_plmc(**kwargs):
     # store useful information about model in outcfg
     outcfg.update({
         "num_sites": plmc_result["num_valid_sites"],
-        "num_sequences": plmc_result["num_valid_seqs"],
+        "num_valid_sequences": plmc_result["num_valid_seqs"],
         "effective_sequences": plmc_result["effective_samples"],
         "region_start": plmc_result["region_start"],
     })
@@ -607,7 +607,7 @@ def mean_field(**kwargs):
     # store useful information about model in outcfg
     outcfg.update({
         "num_sites": model.L,
-        "num_sequences": model.N_valid,
+        "num_valid_sequences": model.N_valid,
         "effective_sequences": float(round(model.N_eff, 1)),
         "region_start": int(model.index_list[0]),
     })


### PR DESCRIPTION
Rename key in couplings out-config from num_sequences to num_valid_sequences to avoid confusion and inconsistencies in final out-config vs. stage out-configs.

Why?

I am storing out configs in the mongo database as dictionaries (losing reference as to which stage the come from, so: imagine a list of dicts in python). If you start querying the collection for dictionaries containing the key "num_sequences" you get two hits (we know: align and couplings) which have **different numbers**. This is very confusing and programmatically it doesn't really make sense.

In the end, I want to merge all outconfigs into one single object (like it is with the global outconfig) but with mongo you can't really guarantee that the order will be preserved!!!!! So... overwriting keys unless necessary seems like a good approach.


This PR is literally just creating another key in the outconfig and avoiding overrides.