### PR TITLE
change ci/cd process from travis to github actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -39,8 +39,3 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         run: coverage run -m unittest discover -s test -p "Test*.py"
-    # - name: Publish evcouplings to PyPI
-    #   if: startsWith(github.ref, 'refs/tags')
-    #   uses: pypa/gh-action-pypi-publish@master
-    #   with:
-    #     password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build_test_and_push.yml
+++ b/.github/workflows/build_test_and_push.yml
@@ -1,0 +1,48 @@
+name: Test and push release to PyPI
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install and configure conda
+      run: |
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+        bash miniconda.sh -b -p $HOME/miniconda
+        export PATH="$HOME/miniconda/bin:$PATH"
+        hash -r
+        conda config --set always_yes yes --set changeps1 no
+        conda update -q conda
+        conda info -a
+        conda create -q -n test-environment python=${{ matrix.python-version }} numpy scipy numba pandas matplotlib
+        source activate test-environment
+    - name: Run setup.py
+      run: |
+        python setup.py sdist --formats=zip -k
+        find ./dist -iname "*.zip" -print0 | xargs -0 pip install
+        pip install codecov
+    - name: Download test files
+      run: |
+        wget https://marks.hms.harvard.edu/evcouplings_test_cases/data/evcouplings_test_cases.tar.gz
+        tar -xf evcouplings_test_cases.tar.gz -C $HOME/
+    - name: Run tests in headless xvfb environment
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        run: coverage run -m unittest discover -s test -p "Test*.py"
+    - name: Publish evcouplings to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build_test_push.yml
+++ b/.github/workflows/build_test_push.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -32,7 +31,16 @@ jobs:
         python setup.py sdist --formats=zip -k
         find ./dist -iname "*.zip" -print0 | xargs -0 pip install
         pip install codecov
+    - name: Download test files
+      run: |
+        "wget https://marks.hms.harvard.edu/evcouplings_test_cases/data/evcouplings_test_cases.tar.gz",
+        "tar -xf evcouplings_test_cases.tar.gz -C $HOME/"
     - name: Run tests in headless xvfb environment
       uses: GabrielBB/xvfb-action@v1
       with:
         run: coverage run -m unittest discover -s test -p "Test*.py"
+    # - name: Publish evcouplings to PyPI
+    #   if: startsWith(github.ref, 'refs/tags')
+    #   uses: pypa/gh-action-pypi-publish@master
+    #   with:
+    #     password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build_test_push.yml
+++ b/.github/workflows/build_test_push.yml
@@ -32,13 +32,11 @@ jobs:
         python setup.py sdist --formats=zip -k
         find ./dist -iname "*.zip" -print0 | xargs -0 pip install
         pip install codecov
-    - name: Test setup
+    - name: Get tests to run
       run: |
-        export DISPLAY=:99.0
-        sh -e /etc/init.d/xvfb start
-        sleep 3
         wget https://marks.hms.harvard.edu/evcouplings/models/data/evcouplings_test_cases.tar.gz
         tar -xf evcouplings_test_cases.tar.gz -C $HOME/
-    - name: Run tests
+    - name: Run tests in headless xvfb environment
+      uses: GabrielBB/xvfb-action@v1
       run: |
         coverage run -m unittest discover -s test -p "Test*.py"

--- a/.github/workflows/build_test_push.yml
+++ b/.github/workflows/build_test_push.yml
@@ -38,5 +38,5 @@ jobs:
         tar -xf evcouplings_test_cases.tar.gz -C $HOME/
     - name: Run tests in headless xvfb environment
       uses: GabrielBB/xvfb-action@v1
-      run: |
-        coverage run -m unittest discover -s test -p "Test*.py"
+      with:
+        run: coverage run -m unittest discover -s test -p "Test*.py"

--- a/.github/workflows/build_test_push.yml
+++ b/.github/workflows/build_test_push.yml
@@ -1,0 +1,44 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install and configure conda
+      run: |
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+        bash miniconda.sh -b -p $HOME/miniconda
+        export PATH="$HOME/miniconda/bin:$PATH"
+        hash -r
+        conda config --set always_yes yes --set changeps1 no
+        conda update -q conda
+        conda info -a
+        conda create -q -n test-environment python=${{ matrix.python-version }} numpy scipy numba pandas matplotlib
+        source activate test-environment
+    - name: Run setup.py
+      run: |
+        python setup.py sdist --formats=zip -k
+        find ./dist -iname "*.zip" -print0 | xargs -0 pip install
+        pip install codecov
+    - name: Test setup
+      run: |
+        export DISPLAY=:99.0
+        sh -e /etc/init.d/xvfb start
+        sleep 3
+        wget https://marks.hms.harvard.edu/evcouplings/models/data/evcouplings_test_cases.tar.gz
+        tar -xf evcouplings_test_cases.tar.gz -C $HOME/
+    - name: Run tests
+      run: |
+        coverage run -m unittest discover -s test -p "Test*.py"

--- a/.github/workflows/build_test_push.yml
+++ b/.github/workflows/build_test_push.yml
@@ -32,10 +32,6 @@ jobs:
         python setup.py sdist --formats=zip -k
         find ./dist -iname "*.zip" -print0 | xargs -0 pip install
         pip install codecov
-    - name: Get tests to run
-      run: |
-        wget https://marks.hms.harvard.edu/evcouplings/models/data/evcouplings_test_cases.tar.gz
-        tar -xf evcouplings_test_cases.tar.gz -C $HOME/
     - name: Run tests in headless xvfb environment
       uses: GabrielBB/xvfb-action@v1
       with:

--- a/.github/workflows/build_test_push.yml
+++ b/.github/workflows/build_test_push.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6]
+        python-version: [3.6]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_test_push.yml
+++ b/.github/workflows/build_test_push.yml
@@ -33,8 +33,8 @@ jobs:
         pip install codecov
     - name: Download test files
       run: |
-        "wget https://marks.hms.harvard.edu/evcouplings_test_cases/data/evcouplings_test_cases.tar.gz",
-        "tar -xf evcouplings_test_cases.tar.gz -C $HOME/"
+        wget https://marks.hms.harvard.edu/evcouplings_test_cases/data/evcouplings_test_cases.tar.gz
+        tar -xf evcouplings_test_cases.tar.gz -C $HOME/
     - name: Run tests in headless xvfb environment
       uses: GabrielBB/xvfb-action@v1
       with:

--- a/test/TestComplex.py
+++ b/test/TestComplex.py
@@ -18,7 +18,8 @@ from evcouplings.complex.similarity import *
 from evcouplings.complex.protocol import *
 from evcouplings.align import Alignment
 
-TRAVIS_PATH = "/home/travis/evcouplings_test_cases/complex_test"
+TRAVIS_PATH = os.getenv('HOME') + "/evcouplings_test_cases/complex_test"
+# TRAVIS_PATH = "/home/travis/evcouplings_test_cases/complex_test"
 # TRAVIS_PATH = "/Users/AG/Dropbox/evcouplings_dev/test_cases/for_B/complex_test"
 
 class TestComplex(TestCase):

--- a/test/TestFold.py
+++ b/test/TestFold.py
@@ -15,7 +15,8 @@ from unittest import TestCase
 from evcouplings.fold import haddock_dist_restraint
 from evcouplings.fold.protocol import complex_dock
 
-TRAVIS_PATH = "/home/travis/evcouplings_test_cases"
+TRAVIS_PATH = os.getenv('HOME') + "/evcouplings_test_cases"
+# TRAVIS_PATH = "/home/travis/evcouplings_test_cases"
 #TRAVIS_PATH = "/Users/AG/Dropbox/evcouplings_dev/test_cases/for_B"
 COMPLEX_PATH = "{}/complex_test".format(TRAVIS_PATH)
 

--- a/test/TestMutation.py
+++ b/test/TestMutation.py
@@ -17,7 +17,8 @@ from evcouplings.mutate.calculations import *
 from evcouplings.mutate.protocol import *
 from evcouplings.couplings.model import CouplingsModel
 
-TRAVIS_PATH = "/home/travis/evcouplings_test_cases"
+TRAVIS_PATH = os.getenv('HOME') + "/evcouplings_test_cases"
+# TRAVIS_PATH = "/home/travis/evcouplings_test_cases"
 #TRAVIS_PATH = "/Users/AG/Dropbox/evcouplings_dev/test_cases/for_B"
 MONOMER_PATH = "{}/monomer_test".format(TRAVIS_PATH)
 COMPLEX_PATH = "{}/complex_test".format(TRAVIS_PATH)

--- a/test/TestUtilsCalculate.py
+++ b/test/TestUtilsCalculate.py
@@ -5,7 +5,7 @@ from evcouplings.couplings import CouplingsModel
 import numpy as np
 
 MONO_MODEL = os.getenv('HOME') + "/evcouplings_test_cases/monomer_test/couplings/RASH_HUMAN_b03.model"
-MONO_MODEL = "/home/travis/evcouplings_test_cases/monomer_test/couplings/RASH_HUMAN_b03.model"
+# MONO_MODEL = "/home/travis/evcouplings_test_cases/monomer_test/couplings/RASH_HUMAN_b03.model"
 
 
 class TestUtilsHelpers(TestCase):

--- a/test/TestUtilsCalculate.py
+++ b/test/TestUtilsCalculate.py
@@ -4,6 +4,7 @@ from evcouplings.utils import *
 from evcouplings.couplings import CouplingsModel
 import numpy as np
 
+MONO_MODEL = os.getenv('HOME') + "/evcouplings_test_cases/monomer_test/couplings/RASH_HUMAN_b03.model"
 MONO_MODEL = "/home/travis/evcouplings_test_cases/monomer_test/couplings/RASH_HUMAN_b03.model"
 
 


### PR DESCRIPTION
github actions allows us to integrate more easily with just this github repo, and has growing support with built in actions/steps. also having secrets hosted on github will allow us to hide our pypi token (and we can generate a new one if we want to change the token from what will be preserved in our git history).

added workflows:
- build_and_test. this builds and tests the package with every push to the repository as well as with every pull request.
- build_test_and_push. this will, when a release is released (as opposed to a release in pre-release or simply when a release is created), build, test, and push the package up to pypi if the release is tagged.