### PR TITLE
fix error arising from import ruamel.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,10 @@ __pycache__
 *.ipynb_checkpoints*
 notebooks_dev/*
 evcouplings.egg-info/*
+
+# ignore working dir
 work/
+
+# ignore build dirs
+build/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.ipynb_checkpoints*
 notebooks_dev/*
 evcouplings.egg-info/*
+work/

--- a/evcouplings/utils/batch.py
+++ b/evcouplings/utils/batch.py
@@ -17,7 +17,7 @@ import time
 import psutil
 import queue
 
-import ruamel.yaml as yaml
+import ruamel_yaml as yaml
 import billiard as mp
 
 from tempfile import NamedTemporaryFile

--- a/evcouplings/utils/config.py
+++ b/evcouplings/utils/config.py
@@ -10,7 +10,7 @@ Authors:
   Thomas A. Hopf
 """
 
-import ruamel.yaml as yaml
+import ruamel_yaml as yaml
 
 
 class MissingParameterError(Exception):


### PR DESCRIPTION
I just tried to install and test your package, `evcoupling`.

I was working from `alignment_analysis.py`  and ran into trouble straight away when trying to import `evcouplings.align`.

The issue seems to be because `ruamel.yaml` has been changed to `ruamel_yaml` in the `ruamel` package. So, the simple fix is to rename these imports. I found two instances of `ruamel.yaml` in `evcouplings/utils/`. (It may also be possible to explicitly declare a version of `ruamel` that still uses `ruamel.yaml`, if that is indeed the problem, in `requirments.txt`). 

I think these changes to the files in `utils/` fix the error:
> ModuleNotFoundError: No module named 'ruamel.yaml' 

I now have a new, probably OS specific, issue:
![image](https://user-images.githubusercontent.com/44420254/112900235-30f66f80-90b1-11eb-93b2-2047423c3fbb.png)

The program is trying to access some graphical interface, but is having trouble on my WSL system-- there is probably some sort of configuration I have overlooked.

