### PR TITLE
Use scikit-learn instead of sklearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     install_requires=['setuptools>=18.2', 'numpy',
         'pandas', 'scipy', 'numba', 'ruamel.yaml', 'matplotlib', 'requests',
         'mmtf-python', 'click', 'filelock', 'psutil', 'bokeh', 'jinja2',
-        'biopython', 'seaborn', 'billiard', 'sklearn',
+        'biopython', 'seaborn', 'billiard', 'scikit-learn',
     ],
 
 )


### PR DESCRIPTION
The `sklearn` package is an empty alias for `scikit-learn`, and its [PyPI description](https://pypi.org/project/sklearn/) recommends to "Use scikit-learn instead". Furthermore, the alias does not exist on Conda repositories, breaking the use of `conda install --file requirements.txt`.

Along with setup.py, requirements.txt has been changed in 5de7bab3b5202848ace2e16ff2b1cda5c8edfda6.