### PR TITLE
change name inputs to bokeh

### DIFF
--- a/evcouplings/visualize/mutations.py
+++ b/evcouplings/visualize/mutations.py
@@ -371,8 +371,8 @@ def matrix_base_bokeh(matrix, positions, substitutions,
     p = bp.figure(
         title=title,
         x_range=positions, y_range=substitutions,
-        x_axis_location="above", plot_width=width_factor * len(positions),
-        plot_height=height_factor * len(substitutions),
+        x_axis_location="above", width=width_factor * len(positions),
+        height=height_factor * len(substitutions),
         toolbar_location="left", tools=TOOLS
     )
 


### PR DESCRIPTION
When attempting to install/run EVCouplings I encountered the following error: 


```sh
  File "/opt/conda/lib/python3.9/site-packages/evcouplings/utils/pipeline.py", line 508, in execute_wrapped
    outcfg = execute(**config)
  File "/opt/conda/lib/python3.9/site-packages/evcouplings/utils/pipeline.py", line 187, in execute
    outcfg = runner(**incfg)
  File "/opt/conda/lib/python3.9/site-packages/evcouplings/mutate/protocol.py", line 326, in run
    return PROTOCOLS[kwargs["protocol"]](**kwargs)
  File "/opt/conda/lib/python3.9/site-packages/evcouplings/mutate/protocol.py", line 91, in standard
    fig = evcouplings.visualize.mutations.plot_mutation_matrix(model, engine="bokeh")
  File "/opt/conda/lib/python3.9/site-packages/evcouplings/visualize/mutations.py", line 220, in plot_mutation_matrix
    return matrix_base_bokeh(
  File "/opt/conda/lib/python3.9/site-packages/evcouplings/visualize/mutations.py", line 371, in matrix_base_bokeh
    p = bp.figure(
  File "/opt/conda/lib/python3.9/site-packages/bokeh/plotting/_figure.py", line 184, in __init__
    self._raise_attribute_error_with_matches(name, names | opts.properties())
  File "/opt/conda/lib/python3.9/site-packages/bokeh/core/has_props.py", line 368, in _raise_attribute_error_with_matches
    raise AttributeError(f"unexpected attribute {name!r} to {self.__class__.__name__}, {text} attributes are {nice_join(matches)}")


AttributeError: unexpected attribute 'plot_width' to figure, similar attributes are outer_width, width or min_width
```


It looks like `bokeh` does not like the passed param names and may have changed / deprecated [these options recently](https://github.com/bokeh/bokeh/blob/62b6cb61b739cf98a40482f038dbd218ed8b26af/docs/CHANGELOG#L637). This PR modifies the param names. 


zach cp