### PR TITLE
fix: match plmc log style

### DIFF
--- a/evcouplings/couplings/tools.py
+++ b/evcouplings/couplings/tools.py
@@ -52,7 +52,7 @@ def parse_plmc_log(log):
         "seqs": re.compile("(\d+) valid sequences out of (\d+)"),
         "sites": re.compile("(\d+) sites out of (\d+)"),
         "region": re.compile("Region starts at (\d+)"),
-        "samples": re.compile("Effective number of samples: (\d+\.\d+)"),
+        "samples": re.compile("Effective number of samples.*: (\d+\.\d+)"),
         "optimization": re.compile("Gradient optimization: (.+)")
     }
 


### PR DESCRIPTION
on my machine, `plmc` log looks like
```
Found focus O88935_B2RQR8 as sequence 1
6 valid sequences out of 6 
1468 sites out of 1469
Region starts at 1
Effective number of samples (to 1 decimal place): 1.0	(60% identical neighborhood = 1.000 samples)
```
which does not match the extraction part of `parse_plmc_log` in https://github.com/debbiemarkslab/EVcouplings/blob/2590f9ee54cbd59bd7ff0bd59875d5a5aac0860b/evcouplings/couplings/tools.py#L55

It will cause `EVcouplings` fails to run subsequent steps.

I made a minor adjustment on the regex to match it.