### PR TITLE
use new API in ruamel.yaml v0.18

### DIFF
--- a/evcouplings/utils/config.py
+++ b/evcouplings/utils/config.py
@@ -84,9 +84,7 @@ def write_config_file(out_filename, config):
     yaml = YAML(typ='safe', pure=True)
     yaml.default_flow_style = False
     with open(out_filename, "w") as f:
-        f.write(
-            yaml.dump(config)
-        )
+        yaml.dump(config, f)
 
 
 def check_required(params, keys):

--- a/evcouplings/utils/config.py
+++ b/evcouplings/utils/config.py
@@ -11,6 +11,7 @@ Authors:
 """
 
 from ruamel.yaml import YAML
+from ruamel.yaml.error import MarkedYAMLError
 
 
 class MissingParameterError(Exception):
@@ -43,11 +44,11 @@ def parse_config(config_str):
     yaml = YAML(typ='safe', pure=True)
     try:
         return yaml.load(config_str)
-    except yaml.parser.ParserError as e:
+    except MarkedYAMLError as e:
         raise InvalidParameterError(
             "Could not parse input configuration. "
             "Formatting mistake in config file? "
-            "See ParserError above for details."
+            "See MarkedYAMLError above for details."
         ) from e
 
 

--- a/evcouplings/utils/config.py
+++ b/evcouplings/utils/config.py
@@ -25,7 +25,7 @@ class InvalidParameterError(Exception):
     """
 
 
-def parse_config(config_str, preserve_order=False):
+def parse_config(config_str):
     """
     Parse a configuration string
 
@@ -33,15 +33,13 @@ def parse_config(config_str, preserve_order=False):
     ----------
     config_str : str
         Configuration to be parsed
-    preserve_order : bool, optional (default: True)
-        Preserve formatting of input configuration
-        string
 
     Returns
     -------
     dict
         Configuration dictionary
     """
+    # uses round-trip loader by default, preserving order
     yaml = YAML(typ='safe', pure=True)
     try:
         return yaml.load(config_str)
@@ -53,7 +51,7 @@ def parse_config(config_str, preserve_order=False):
         ) from e
 
 
-def read_config_file(filename, preserve_order=False):
+def read_config_file(filename):
     """
     Read and parse a configuration file.
 
@@ -68,7 +66,7 @@ def read_config_file(filename, preserve_order=False):
         Configuration dictionary
     """
     with open(filename) as f:
-        return parse_config(f, preserve_order)
+        return parse_config(f)
 
 
 def write_config_file(out_filename, config):

--- a/evcouplings/utils/config.py
+++ b/evcouplings/utils/config.py
@@ -10,7 +10,7 @@ Authors:
   Thomas A. Hopf
 """
 
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
 
 
 class MissingParameterError(Exception):
@@ -42,11 +42,9 @@ def parse_config(config_str, preserve_order=False):
     dict
         Configuration dictionary
     """
+    yaml = YAML(typ='safe', pure=True)
     try:
-        if preserve_order:
-            return yaml.load(config_str, Loader=yaml.RoundTripLoader)
-        else:
-            return yaml.safe_load(config_str)
+        return yaml.load(config_str)
     except yaml.parser.ParserError as e:
         raise InvalidParameterError(
             "Could not parse input configuration. "
@@ -84,14 +82,11 @@ def write_config_file(out_filename, config):
     config : dict
         Config data that will be written to file
     """
-    if isinstance(config, yaml.comments.CommentedBase):
-        dumper = yaml.RoundTripDumper
-    else:
-        dumper = yaml.Dumper
-
+    yaml = YAML(typ='safe', pure=True)
+    yaml.default_flow_style = False
     with open(out_filename, "w") as f:
         f.write(
-            yaml.dump(config, Dumper=dumper, default_flow_style=False)
+            yaml.dump(config)
         )
 
 


### PR DESCRIPTION
The round-trip loader is now default in ruamel.yaml. So the config parser can be simplified to always preserve order.